### PR TITLE
update to bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,18 +6,18 @@ description = "Bevy plugin for better task handling"
 license = "MIT"
 repository = "https://github.com/Demiu/bevy_background_compute"
 documentation = "https://docs.rs/bevy_background_compute"
-keywords = [
-    "bevy",
-]
+keywords = ["bevy"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # something with a dedicated oneshot channel would be ideal but bevy already has this as a dep
-async-channel = "^1.7.1" 
-bevy_app = "0.12"
-bevy_ecs = "0.12"
-bevy_tasks = { version = "0.12", features = ["multi-threaded"] } # TODO remove the feature if it will be added to default set
+async-channel = "2.2.0"
+bevy_app = "0.13"
+bevy_ecs = "0.13"
+bevy_tasks = { version = "0.13", features = [
+    "multi-threaded",
+] } # TODO remove the feature if it will be added to default set
 
 [dev-dependencies]
-bevy = { version = "0.12", default-features = false }
+bevy = { version = "0.13", default-features = false }

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -49,7 +49,7 @@ fn background_compute_callback(
     mut events: EventReader<BackgroundComputeComplete<FunnyNumber>>,
     mut exit: EventWriter<AppExit>,
 ) {
-    if events.len() > 0 {
+    if !events.is_empty() {
         println!(
             "Funny number found: {:?}",
             events.read().next().unwrap().0 .0


### PR DESCRIPTION
bevy 0.13 compat

- fixed minor clippy warning
- updated cargo to bevy 0.13
- updated async-channel dep to 2.2.0

No other changes were needed.